### PR TITLE
Allow Jest 20.x as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "xmlbuilder": "8.2.2"
   },
   "peerDependencies": {
-    "jest": "19.x"
+    "jest": "19.x || 20.x"
   }
 }


### PR DESCRIPTION
Hi,

we  are using `jest-html-reporter` with Jest 20.x, and it's running just fine.
Only the peerDependency is an issue, especially with generating a schrinkwrap.