### PR TITLE
Fix missing comma in exports

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -142,7 +142,7 @@ module.exports = {
 	createHtml,
 	getOutputFilepath,
 	getStylesheet,
-	logMessage
+	logMessage,
 	renderHTML,
 	writeFile,
 };


### PR DESCRIPTION
Hi @Hargne , thanks for making this package! When trying to use it to generate html reports from jest, I received the following cryptic error:
```
(node:87558) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): SyntaxError: Unexpected identifier
(node:87558) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

It turns out the error was a missing comma in `src/methods.js`.

It also seems like `npm test` fails locally before this fix. After this fix, `npm test` passes.