### PR TITLE
Use TEST_REPORT_PATH env variable

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -29,7 +29,7 @@ const logMessage = (type, msg) => {
  * Returns the output path for the test report
  * @return {String}
  */
-const getOutputFilepath = () => config.outputPath || path.join(process.cwd(), 'test-report.html');
+const getOutputFilepath = () => config.outputPath || process.env.TEST_REPORT_PATH || path.join(process.cwd(), 'test-report.html');
 /**
  * Creates a file at the given destination
  * @param  {String} filePath


### PR DESCRIPTION
Override default output path `test-report.html` by env variable.

It's may be useful, if we want to change report filename cross builds in CI/CD