### PR TITLE
Env var for report title and use case example added to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,17 @@ Have a look at the default styling (located within this repository at *src/style
 	}
 }
 ```
+
+## Continuous Integration
+
+The output path and report title can be set with an environment variable for dynamic file saving paths in different environments. 
+
+Values in package.json will take precedence over environment variables.
+
+Here is an example of dynamically naming your output file and test report title to match your current branch that one might see in a automated deployment pipeline before running their tests.
+
+~~~ bash
+export BRANCH_NAME=`git symbolic-ref HEAD 2>/dev/null | cut -d"/" -f 3`
+export TEST_REPORT_PATH=/home/username/jest-test-output/test-reports/"$BRANCH_NAME".html
+export TEST_REPORT_TITLE="$BRANCH_NAME"\ Test\ Report
+~~~

--- a/src/methods.js
+++ b/src/methods.js
@@ -60,11 +60,11 @@ const createHtml = (stylesheet) => xmlbuilder.create({
 	html: {
 		head: {
 			meta: { '@charset': 'utf-8' },
-			title: { '#text': config.pageTitle || 'Test suite' },
+			title: { '#text': config.pageTitle || process.env.TEST_REPORT_TITLE || 'Test suite' },
 			style: { '@type': 'text/css', '#text': stylesheet },
 		},
 		body: {
-			h1: { '#text': config.pageTitle || 'Test suite' },
+			h1: { '#text': config.pageTitle || process.env.TEST_REPORT_TITLE || 'Test suite' },
 		},
 	},
 });


### PR DESCRIPTION
Have env var as an option for report title.

Provide a use case for env vars in readme.