### PR TITLE
Feature/add sort option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ To configure this plugin, create a file named `jesthtmlreporter.config.json` in 
 | `theme` | `STRING` | The name of the reporter themes to use when rendering the report. Available themes are located within *style/* | `"defaultTheme"`
 | `executionTimeWarningThreshold` | `NUMBER` | The threshold for test execution time (in seconds) in each test suite that will render a warning on the report page. 5 seconds is the default timeout in Jest. | `5`
 | `dateFormat` | `STRING` | The format in which date/time should be formatted in the test report. Have a look in the [Wiki](https://github.com/Hargne/jest-html-reporter/wiki/Date-Format) for the available date format variables. | `"yyyy-mm-dd HH:MM:ss"`
+| `sort` | `STRING` | The default setting has no effect, set to `status` to sort pending tests to the top, followed by failing tests and then passing tests. | `default`
 
 #### *A note on styleOverridePath
 The plugin will search for the file from the root directory, therefore there is no need to prepend the string with ./ or ../
@@ -119,4 +120,5 @@ The environment variables reflect the properties set in the JSON configuration f
 * `JEST_HTML_REPORTER_THEME`
 * `JEST_HTML_REPORTER_EXECUTION_TIME_WARNING_THRESHOLD`
 * `JEST_HTML_REPORTER_DATE_FORMAT`
+* `JEST_HTML_REPORTER_SORT`
 

--- a/src/config.js
+++ b/src/config.js
@@ -68,6 +68,9 @@ const getExecutionTimeWarningThreshold = () =>
 const getDateFormat = () =>
 	config.dateFormat || process.env.JEST_HTML_REPORTER_DATE_FORMAT || 'yyyy-mm-dd HH:MM:ss';
 
+const getSort = () =>
+	config.sort || process.env.JEST_HTML_REPORTER_SORT || 'default';
+
 module.exports = {
 	config,
 	getOutputFilepath,
@@ -77,4 +80,5 @@ module.exports = {
 	getExecutionTimeWarningThreshold,
 	getTheme,
 	getDateFormat,
+	getSort,
 };

--- a/src/methods.js
+++ b/src/methods.js
@@ -63,7 +63,7 @@ const processTestSuiteResults = (suiteResults, sort) => {
 
 		return [].concat(pendingSuites, failingSuites, passingSuites);
 	}
-	
+
 	return suiteResults;
 };
 

--- a/src/methods.js
+++ b/src/methods.js
@@ -26,6 +26,33 @@ const logMessage = ({ type, msg, ignoreConsole }) => {
 	return { logColor, logMsg }; // Return for testing purposes
 };
 
+const sortTestResults = (testResults, sort) => {
+	if (!sort || sort === 'default') {
+		return testResults;
+	}
+	if (sort === 'status') {
+		return testResults
+			.slice()
+			.sort((a, b) => {
+				if (a.numPendingTests > 0 && b.numPendingTests === 0) {
+					return -1;
+				}
+				if (b.numPendingTests > 0 && a.numPendingTests === 0) {
+					return 1;
+				}
+				if (a.numFailingTests > 0 && b.numFailingTests === 0) {
+					return -1;
+				}
+				if (b.numFailingTests > 0 && a.numFailingTests === 0) {
+					return 1;
+				}
+				return 0;
+			});
+	}
+
+	return testResults;
+};
+
 /**
  * Creates a file at the given destination
  * @param  {String} filePath
@@ -98,8 +125,10 @@ const renderHTML = (testData, stylesheet) => new Promise((resolve, reject) => {
 		${testData.numPendingTests} pending
 	`);
 
+	const sortedTestResults = sortTestResults(testData.testResults, config.getSort());
+
 	// Test Suites
-	testData.testResults.forEach((suite) => {
+	sortedTestResults.forEach((suite) => {
 		if (!suite.testResults || suite.testResults.length <= 0) { return; }
 
 		// Suite Information
@@ -162,6 +191,7 @@ const createReport = (testData, ignoreConsole) => {
 
 module.exports = {
 	logMessage,
+	sortTestResults,
 	writeFile,
 	createReport,
 	createHtml,

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -1,0 +1,59 @@
+/**
+ * Splits test suites apart based on individual test status and sorts by that status:
+ * 1. Pending
+ * 2. Failed
+ * 3. Passed
+ * @param {Array<Object>} suiteResults
+ */
+const sortSuiteResultsByStatus = (suiteResults) => {
+	const pendingSuites = [];
+	const failingSuites = [];
+	const passingSuites = [];
+
+	suiteResults.forEach((suiteResult) => {
+		const pending = [];
+		const failed = [];
+		const passed = [];
+
+		suiteResult.testResults.forEach((x) => {
+			if (x.status === 'pending') {
+				pending.push(x);
+			} else if (x.status === 'failed') {
+				failed.push(x);
+			} else {
+				passed.push(x);
+			}
+		});
+
+		if (pending.length) {
+			pendingSuites.push(Object.assign({}, suiteResult, { testResults: pending }));
+		}
+		if (failed.length) {
+			failingSuites.push(Object.assign({}, suiteResult, { testResults: failed }));
+		}
+		if (passed.length) {
+			passingSuites.push(Object.assign({}, suiteResult, { testResults: passed }));
+		}
+	});
+
+	return [].concat(pendingSuites, failingSuites, passingSuites);
+};
+
+/**
+ * Sorts test suite results
+ * If sort is undefined or is not a supported value this has no effect
+ * @param {Array<Object>} suiteResults
+ * @param {String} sort The configured sort
+ */
+const sortSuiteResults = (suiteResults, sort) => {
+	if (sort === 'status') {
+		return sortSuiteResultsByStatus(suiteResults);
+	}
+
+	return suiteResults;
+};
+
+module.exports = {
+	sortSuiteResults,
+	sortSuiteResultsByStatus,
+};

--- a/test/_mockdata-sorting.js
+++ b/test/_mockdata-sorting.js
@@ -1,0 +1,121 @@
+module.exports = {
+	jestTestData: {
+		success: true,
+		startTime: 1498476492,
+		numTotalTestSuites: 3,
+		numPassedTestSuites: 1,
+		numFailedTestSuites: 2,
+		numRuntimeErrorTestSuites: 1,
+		numTotalTests: 9,
+		numPassedTests: 6,
+		numFailedTests: 2,
+		numPendingTests: 1,
+		testResults: [
+			{
+				numFailingTests: 0,
+				numPassingTests: 3,
+				numPendingTests: 0,
+				testResults: [
+					{
+						title: 'title',
+						status: 'passed',
+						ancestorTitles: ['ancestor'],
+						failureMessages: [],
+						numPassingAsserts: 0,
+					},
+					{
+						title: 'title',
+						status: 'passed',
+						ancestorTitles: ['ancestor'],
+						failureMessages: [],
+						numPassingAsserts: 0,
+					},
+					{
+						title: 'title',
+						status: 'passed',
+						ancestorTitles: ['ancestor'],
+						failureMessages: [],
+						numPassingAsserts: 0,
+					},
+				],
+				perfStats: {
+					start: 1498476492,
+					end: 1498476639,
+				},
+				testFilePath: 'index-a.js',
+			},
+			{
+				numFailingTests: 1,
+				numPassingTests: 2,
+				numPendingTests: 0,
+				testResults: [
+					{
+						title: 'title',
+						status: 'passed',
+						ancestorTitles: ['ancestor'],
+						failureMessages: [],
+						numPassingAsserts: 0,
+					},
+					{
+						title: 'title',
+						status: 'failed',
+						ancestorTitles: ['ancestor'],
+						failureMessages: ['failure'],
+						numPassingAsserts: 0,
+					},
+					{
+						title: 'title',
+						status: 'passed',
+						ancestorTitles: ['ancestor'],
+						failureMessages: [],
+						numPassingAsserts: 0,
+					},
+				],
+				perfStats: {
+					start: 1498476492,
+					end: 1498476639,
+				},
+				testFilePath: 'index-b.js',
+			},
+			{
+				numFailingTests: 0,
+				numPassingTests: 2,
+				numPendingTests: 1,
+				testResults: [
+					{
+						title: 'title',
+						status: 'passed',
+						ancestorTitles: ['ancestor'],
+						failureMessages: [],
+						numPassingAsserts: 0,
+					},
+					{
+						title: 'title',
+						status: 'passed',
+						ancestorTitles: ['ancestor'],
+						failureMessages: [],
+						numPassingAsserts: 0,
+					},
+					{
+						title: 'title',
+						status: 'pending',
+						ancestorTitles: ['ancestor'],
+						failureMessages: [],
+						numPassingAsserts: 0,
+					},
+				],
+				perfStats: {
+					start: 1498476492,
+					end: 1498476639,
+				},
+				testFilePath: 'index-c.js',
+			},
+			{
+				numFailingTests: 0,
+				numPassingTests: 0,
+				numPendingTests: 0,
+				testResults: [],
+			},
+		],
+	},
+};

--- a/test/_mockdata-sorting.js
+++ b/test/_mockdata-sorting.js
@@ -4,11 +4,11 @@ module.exports = {
 		startTime: 1498476492,
 		numTotalTestSuites: 3,
 		numPassedTestSuites: 1,
-		numFailedTestSuites: 2,
+		numFailedTestSuites: 1,
 		numRuntimeErrorTestSuites: 1,
 		numTotalTests: 9,
-		numPassedTests: 6,
-		numFailedTests: 2,
+		numPassedTests: 7,
+		numFailedTests: 1,
 		numPendingTests: 1,
 		testResults: [
 			{
@@ -46,12 +46,12 @@ module.exports = {
 			},
 			{
 				numFailingTests: 1,
-				numPassingTests: 2,
-				numPendingTests: 0,
+				numPassingTests: 1,
+				numPendingTests: 1,
 				testResults: [
 					{
 						title: 'title',
-						status: 'passed',
+						status: 'pending',
 						ancestorTitles: ['ancestor'],
 						failureMessages: [],
 						numPassingAsserts: 0,
@@ -78,27 +78,27 @@ module.exports = {
 				testFilePath: 'index-b.js',
 			},
 			{
-				numFailingTests: 0,
-				numPassingTests: 2,
+				numFailingTests: 1,
+				numPassingTests: 1,
 				numPendingTests: 1,
 				testResults: [
 					{
 						title: 'title',
-						status: 'passed',
-						ancestorTitles: ['ancestor'],
-						failureMessages: [],
-						numPassingAsserts: 0,
-					},
-					{
-						title: 'title',
-						status: 'passed',
-						ancestorTitles: ['ancestor'],
-						failureMessages: [],
-						numPassingAsserts: 0,
-					},
-					{
-						title: 'title',
 						status: 'pending',
+						ancestorTitles: ['ancestor'],
+						failureMessages: [],
+						numPassingAsserts: 0,
+					},
+					{
+						title: 'title',
+						status: 'failed',
+						ancestorTitles: ['ancestor'],
+						failureMessages: ['failure'],
+						numPassingAsserts: 0,
+					},
+					{
+						title: 'title',
+						status: 'passed',
 						ancestorTitles: ['ancestor'],
 						failureMessages: [],
 						numPassingAsserts: 0,
@@ -109,12 +109,6 @@ module.exports = {
 					end: 1498476639,
 				},
 				testFilePath: 'index-c.js',
-			},
-			{
-				numFailingTests: 0,
-				numPassingTests: 0,
-				numPendingTests: 0,
-				testResults: [],
 			},
 		],
 	},

--- a/test/methods.spec.js
+++ b/test/methods.spec.js
@@ -1,5 +1,6 @@
 const methods = require('../src/methods');
 const mockdata = require('./_mockdata');
+const mockdataSorting = require('./_mockdata-sorting');
 
 describe('methods', () => {
 	describe('createReport ', () => {
@@ -12,6 +13,35 @@ describe('methods', () => {
 			expect.assertions(1);
 			return methods.createReport(null, true)
 				.then(response => expect(response.logMsg).toEqual('jest-html-reporter >> Error: Test data missing or malformed'));
+		});
+	});
+
+	describe('sort', () => {
+		it('should have a default sort', () => {
+			expect(require('../src/config').getSort()).toEqual('default'); // eslint-disable-line
+		});
+
+		it('should have no effect when sort not configured', () => {
+			const { testResults } = mockdataSorting.jestTestData;
+			const sortedTestResults = methods.sortTestResults(testResults);
+			testResults.forEach((testResult, index) => {
+				expect(sortedTestResults[index].numPassingTests).toEqual(testResult.numPassingTests);
+			});
+		});
+
+		it('should float pending tests to the top when configured as "status"', () => {
+			const { testResults } = mockdataSorting.jestTestData;
+			const sortedTestResults = methods.sortTestResults(testResults, 'status');
+
+			expect(sortedTestResults[0].numPendingTests > 0).toBeTruthy();
+		});
+
+		it('should float failing tests after pending tests when configured as "status"', () => {
+			const { testResults } = mockdataSorting.jestTestData;
+			const sortedTestResults = methods.sortTestResults(testResults, 'status');
+
+			expect(sortedTestResults[0].numFailingTests === 0).toBeTruthy();
+			expect(sortedTestResults[1].numFailingTests > 0).toBeTruthy();
 		});
 	});
 

--- a/test/methods.spec.js
+++ b/test/methods.spec.js
@@ -1,6 +1,5 @@
 const methods = require('../src/methods');
 const mockdata = require('./_mockdata');
-const mockdataSorting = require('./_mockdata-sorting');
 
 describe('methods', () => {
 	describe('createReport ', () => {
@@ -13,86 +12,6 @@ describe('methods', () => {
 			expect.assertions(1);
 			return methods.createReport(null, true)
 				.then(response => expect(response.logMsg).toEqual('jest-html-reporter >> Error: Test data missing or malformed'));
-		});
-	});
-
-	describe('sort', () => {
-		/*
-			see _mockdata-sorting for test data
-
-			expected results for "status" are:
-				pending from index-b
-				pending from index-c
-				failed from index-b
-				failed from index-c
-				passed from index-a
-				passed from index-b
-				passed from index-c
-
-			meaning that the results are now broken into three sections:
-			1. pending
-			2. failed
-			3. passed
-
-			the pending and failed sections' sorting should match the passed section's sorting to make tests easier to find
-		*/
-
-		it('should have no effect when sort not configured', () => {
-			const { testResults } = mockdataSorting.jestTestData;
-			const sortedTestResults = methods.processTestSuiteResults(testResults, undefined);
-
-			expect(sortedTestResults.length).toEqual(testResults.length);
-
-			testResults.forEach((testResult, index) => {
-				expect(sortedTestResults[index].testFilePath).toEqual(testResult.testFilePath);
-			});
-		});
-
-		it('should order results as 1.pending 2.failed 3.passed when configured as "status"', () => {
-			const { testResults } = mockdataSorting.jestTestData;
-			const sortedTestResults = methods.processTestSuiteResults(testResults, 'status');
-
-			// pending
-			expect(sortedTestResults[0].testResults.length).toEqual(1);
-			expect(sortedTestResults[0].numPendingTests).toEqual(1);
-			expect(sortedTestResults[0].testFilePath).toEqual('index-b.js');
-
-			expect(sortedTestResults[1].testResults.length).toEqual(1);
-			expect(sortedTestResults[1].numPendingTests).toEqual(1);
-			expect(sortedTestResults[1].testFilePath).toEqual('index-c.js');
-
-			// failed
-			expect(sortedTestResults[2].testResults.length).toEqual(1);
-			expect(sortedTestResults[2].numFailingTests).toEqual(1);
-			expect(sortedTestResults[2].testFilePath).toEqual('index-b.js');
-
-			expect(sortedTestResults[3].testResults.length).toEqual(1);
-			expect(sortedTestResults[3].numFailingTests).toEqual(1);
-			expect(sortedTestResults[3].testFilePath).toEqual('index-c.js');
-
-			// passed
-			expect(sortedTestResults[4].testResults.length).toEqual(3);
-			expect(sortedTestResults[4].numPassingTests).toEqual(3);
-			expect(sortedTestResults[4].testFilePath).toEqual('index-a.js');
-
-			expect(sortedTestResults[5].testResults.length).toEqual(1);
-			expect(sortedTestResults[5].numPassingTests).toEqual(1);
-			expect(sortedTestResults[5].testFilePath).toEqual('index-b.js');
-
-			expect(sortedTestResults[6].testResults.length).toEqual(1);
-			expect(sortedTestResults[6].numPassingTests).toEqual(1);
-			expect(sortedTestResults[6].testFilePath).toEqual('index-c.js');
-		});
-
-		it('should sort all passed tests as default when configured as "status"', () => {
-			const { testResults } = mockdataSorting.jestTestData;
-			const sortedTestResults = methods.processTestSuiteResults(testResults, 'status');
-
-			// skipping the pending and failed sections of the output, the remainder should match
-			// currently the test data has two suites that each have one failed and one pending test, so skip 4
-			expect(sortedTestResults[4].testFilePath).toEqual(testResults[0].testFilePath);
-			expect(sortedTestResults[5].testFilePath).toEqual(testResults[1].testFilePath);
-			expect(sortedTestResults[6].testFilePath).toEqual(testResults[2].testFilePath);
 		});
 	});
 

--- a/test/methods.spec.js
+++ b/test/methods.spec.js
@@ -17,31 +17,82 @@ describe('methods', () => {
 	});
 
 	describe('sort', () => {
-		it('should have a default sort', () => {
-			expect(require('../src/config').getSort()).toEqual('default'); // eslint-disable-line
-		});
+		/*
+			see _mockdata-sorting for test data
+
+			expected results for "status" are:
+				pending from index-b
+				pending from index-c
+				failed from index-b
+				failed from index-c
+				passed from index-a
+				passed from index-b
+				passed from index-c
+
+			meaning that the results are now broken into three sections:
+			1. pending
+			2. failed
+			3. passed
+
+			the pending and failed sections' sorting should match the passed section's sorting to make tests easier to find
+		*/
 
 		it('should have no effect when sort not configured', () => {
 			const { testResults } = mockdataSorting.jestTestData;
-			const sortedTestResults = methods.sortTestResults(testResults);
+			const sortedTestResults = methods.processTestSuiteResults(testResults, undefined);
+
+			expect(sortedTestResults.length).toEqual(testResults.length);
+
 			testResults.forEach((testResult, index) => {
-				expect(sortedTestResults[index].numPassingTests).toEqual(testResult.numPassingTests);
+				expect(sortedTestResults[index].testFilePath).toEqual(testResult.testFilePath);
 			});
 		});
 
-		it('should float pending tests to the top when configured as "status"', () => {
+		it('should order results as 1.pending 2.failed 3.passed when configured as "status"', () => {
 			const { testResults } = mockdataSorting.jestTestData;
-			const sortedTestResults = methods.sortTestResults(testResults, 'status');
+			const sortedTestResults = methods.processTestSuiteResults(testResults, 'status');
 
-			expect(sortedTestResults[0].numPendingTests > 0).toBeTruthy();
+			// pending
+			expect(sortedTestResults[0].testResults.length).toEqual(1);
+			expect(sortedTestResults[0].numPendingTests).toEqual(1);
+			expect(sortedTestResults[0].testFilePath).toEqual('index-b.js');
+
+			expect(sortedTestResults[1].testResults.length).toEqual(1);
+			expect(sortedTestResults[1].numPendingTests).toEqual(1);
+			expect(sortedTestResults[1].testFilePath).toEqual('index-c.js');
+
+			// failed
+			expect(sortedTestResults[2].testResults.length).toEqual(1);
+			expect(sortedTestResults[2].numFailingTests).toEqual(1);
+			expect(sortedTestResults[2].testFilePath).toEqual('index-b.js');
+
+			expect(sortedTestResults[3].testResults.length).toEqual(1);
+			expect(sortedTestResults[3].numFailingTests).toEqual(1);
+			expect(sortedTestResults[3].testFilePath).toEqual('index-c.js');
+
+			// passed
+			expect(sortedTestResults[4].testResults.length).toEqual(3);
+			expect(sortedTestResults[4].numPassingTests).toEqual(3);
+			expect(sortedTestResults[4].testFilePath).toEqual('index-a.js');
+
+			expect(sortedTestResults[5].testResults.length).toEqual(1);
+			expect(sortedTestResults[5].numPassingTests).toEqual(1);
+			expect(sortedTestResults[5].testFilePath).toEqual('index-b.js');
+
+			expect(sortedTestResults[6].testResults.length).toEqual(1);
+			expect(sortedTestResults[6].numPassingTests).toEqual(1);
+			expect(sortedTestResults[6].testFilePath).toEqual('index-c.js');
 		});
 
-		it('should float failing tests after pending tests when configured as "status"', () => {
+		it('should sort all passed tests as default when configured as "status"', () => {
 			const { testResults } = mockdataSorting.jestTestData;
-			const sortedTestResults = methods.sortTestResults(testResults, 'status');
+			const sortedTestResults = methods.processTestSuiteResults(testResults, 'status');
 
-			expect(sortedTestResults[0].numFailingTests === 0).toBeTruthy();
-			expect(sortedTestResults[1].numFailingTests > 0).toBeTruthy();
+			// skipping the pending and failed sections of the output, the remainder should match
+			// currently the test data has two suites that each have one failed and one pending test, so skip 4
+			expect(sortedTestResults[4].testFilePath).toEqual(testResults[0].testFilePath);
+			expect(sortedTestResults[5].testFilePath).toEqual(testResults[1].testFilePath);
+			expect(sortedTestResults[6].testFilePath).toEqual(testResults[2].testFilePath);
 		});
 	});
 

--- a/test/sorting.spec.js
+++ b/test/sorting.spec.js
@@ -1,0 +1,84 @@
+const sorting = require('../src/sorting');
+const mockdataSorting = require('./_mockdata-sorting');
+
+describe('sorting', () => {
+	it('should have no effect when sort not configured', () => {
+		const { testResults } = mockdataSorting.jestTestData;
+		const sortedTestResults = sorting.sortSuiteResults(testResults, undefined);
+
+		expect(sortedTestResults.length).toEqual(testResults.length);
+
+		testResults.forEach((testResult, index) => {
+			expect(sortedTestResults[index].testFilePath).toEqual(testResult.testFilePath);
+		});
+	});
+
+	describe('sortByStatus', () => {
+		/*
+			see _mockdata-sorting for test data
+
+			expected results for "status" are:
+				pending from index-b
+				pending from index-c
+				failed from index-b
+				failed from index-c
+				passed from index-a
+				passed from index-b
+				passed from index-c
+
+			meaning that the results are now broken into three sections:
+			1. pending
+			2. failed
+			3. passed
+
+			the pending and failed sections' sorting should match the passed section's sorting to make tests easier to find
+		*/
+
+		it('should order results as 1.pending 2.failed 3.passed', () => {
+			const { testResults } = mockdataSorting.jestTestData;
+			const sortedTestResults = sorting.sortSuiteResultsByStatus(testResults);
+
+			// pending
+			expect(sortedTestResults[0].testResults.length).toEqual(1);
+			expect(sortedTestResults[0].numPendingTests).toEqual(1);
+			expect(sortedTestResults[0].testFilePath).toEqual('index-b.js');
+
+			expect(sortedTestResults[1].testResults.length).toEqual(1);
+			expect(sortedTestResults[1].numPendingTests).toEqual(1);
+			expect(sortedTestResults[1].testFilePath).toEqual('index-c.js');
+
+			// failed
+			expect(sortedTestResults[2].testResults.length).toEqual(1);
+			expect(sortedTestResults[2].numFailingTests).toEqual(1);
+			expect(sortedTestResults[2].testFilePath).toEqual('index-b.js');
+
+			expect(sortedTestResults[3].testResults.length).toEqual(1);
+			expect(sortedTestResults[3].numFailingTests).toEqual(1);
+			expect(sortedTestResults[3].testFilePath).toEqual('index-c.js');
+
+			// passed
+			expect(sortedTestResults[4].testResults.length).toEqual(3);
+			expect(sortedTestResults[4].numPassingTests).toEqual(3);
+			expect(sortedTestResults[4].testFilePath).toEqual('index-a.js');
+
+			expect(sortedTestResults[5].testResults.length).toEqual(1);
+			expect(sortedTestResults[5].numPassingTests).toEqual(1);
+			expect(sortedTestResults[5].testFilePath).toEqual('index-b.js');
+
+			expect(sortedTestResults[6].testResults.length).toEqual(1);
+			expect(sortedTestResults[6].numPassingTests).toEqual(1);
+			expect(sortedTestResults[6].testFilePath).toEqual('index-c.js');
+		});
+
+		it('should sort all passed tests as default', () => {
+			const { testResults } = mockdataSorting.jestTestData;
+			const sortedTestResults = sorting.sortSuiteResultsByStatus(testResults);
+
+			// skipping the pending and failed sections of the output, the remainder should match
+			// currently the test data has two suites that each have one failed and one pending test, so skip 4
+			expect(sortedTestResults[4].testFilePath).toEqual(testResults[0].testFilePath);
+			expect(sortedTestResults[5].testFilePath).toEqual(testResults[1].testFilePath);
+			expect(sortedTestResults[6].testFilePath).toEqual(testResults[2].testFilePath);
+		});
+	});
+});


### PR DESCRIPTION
adds "sort" configuration option.
the default value has no effect, to avoid introducing a breaking change.
when set to "status", the results will be ordered as pending, failed, passed.

the intention is to make it easier to identify and fix failed tests by bringing them to your attention

current:
<img width="393" alt="screen shot 2018-02-06 at 6 46 59 pm" src="https://user-images.githubusercontent.com/23535291/35890538-2d94639a-0b6e-11e8-80e8-2fe65ee00bc6.png">

new with "sort" set to "status":
<img width="371" alt="screen shot 2018-02-06 at 6 46 44 pm" src="https://user-images.githubusercontent.com/23535291/35890537-2d82531c-0b6e-11e8-8214-a0f4054ee41e.png">
