### PR TITLE
Preseve error message formatting

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -140,7 +140,7 @@ const renderHTML = (testData, stylesheet) => new Promise((resolve, reject) => {
 			if (test.failureMessages && (config.shouldIncludeFailureMessages())) {
 				const failureMsgDiv = testTitleTd.ele('div', { class: 'failureMessages' });
 				test.failureMessages.forEach((failureMsg) => {
-					failureMsgDiv.ele('p', { class: 'failureMsg' }, stripAnsi(failureMsg));
+					failureMsgDiv.ele('pre', { class: 'failureMsg' }, stripAnsi(failureMsg));
 				});
 			}
 


### PR DESCRIPTION
I'd suggest using a `pre` when showing error messages, to preserve the original formatting.
This produces more readable error messages in most cases (stacktraces, snapshots diff)