### PR TITLE
Fix for customScript script tag not being written correctly by xmlwriter

### DIFF
--- a/src/reportGenerator.js
+++ b/src/reportGenerator.js
@@ -159,7 +159,7 @@ class ReportGenerator {
 			// Custom Javascript
 			const customScript = this.config.getCustomScriptFilepath();
 			if (customScript) {
-				htmlOutput.ele('script', { src: customScript });
+				htmlOutput.raw(`<script src="${customScript}"></script>`);
 			}
 			return resolve(htmlOutput);
 		});


### PR DESCRIPTION
I noticed that if a custom external javascript file was specified, the [xmlwriter-js](https://github.com/oozcitak/xmlbuilder-js) would output a self-closing script tag like the following:
```html
<script src="source.js"/>
```

Although this is correct as far as XHTML is concerned, it was causing problems for viewing in Chrome. This would cause chrome not to load the script and chrome would actually try to guess a closing tag for script and make it 

```html
<script src="source.js"/>/html></script>
```

Anyways, I used the [Raw Text Nodes](https://github.com/oozcitak/xmlbuilder-js/wiki#raw-text-nodes) functionality of [xmlwriter-js](https://github.com/oozcitak/xmlbuilder-js) to output a script tag that isn't self-closing.

There is a good amount of info on self-closing script tags [in this answer on stack overflow](https://stackoverflow.com/questions/69913/why-dont-self-closing-script-tags-work). Really this isn't fixing a bug, just making it more compatible. 

P.S. Thanks for this library, exactly what I needed so I appreciate the hard work!