### PR TITLE
Stable Output Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Please note that all configuration properties are optional.
 | `executionTimeWarningThreshold` | `NUMBER` | The threshold for test execution time (in seconds) in each test suite that will render a warning on the report page. 5 seconds is the default timeout in Jest. | `5`
 | `dateFormat` | `STRING` | The format in which date/time should be formatted in the test report. Have a look in the [documentation](https://github.com/Hargne/jest-html-reporter/wiki/Date-Format) for the available date format variables. | `"yyyy-mm-dd HH:MM:ss"`
 | `sort` | `STRING` | Sorts the test results using the given method. Available sorting methods can be found in the [documentation](https://github.com/Hargne/jest-html-reporter/wiki/Sorting-Methods). | `"default"`
+| `stable` | `BOOLEAN` | Omit content in the output (like timestamps) that would cause multiple reports for the same source to differ. | `false`
 
 > *The plugin will search for the *styleOverridePath* from the root directory, therefore there is no need to prepend the string with `./` or `../` - You can read more about the themes in the [documentation](https://github.com/Hargne/jest-html-reporter/wiki/Test-Report-Themes).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-html-reporter",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,24 @@ const fs = require('fs');
 // Initialize an empty config object
 const config = {};
 
+function parseBool(value) {
+	if (typeof value === 'boolean') {
+		return value;
+	}
+	if (typeof value !== 'string') {
+		// eslint-disable-next-line no-console
+		console.error(`Unexpected boolean value '${value}': ${typeof value}`);
+		return true;
+	}
+	try {
+		return JSON.parse(value);
+	} catch (e) {
+		// eslint-disable-next-line no-console
+		console.error(`Unexpected boolean value '${value}': ${e}`);
+		return true;
+	}
+}
+
 /**
  * Assigns the given data to the config object
  * @param {Object} data
@@ -74,21 +92,21 @@ const getLogo = () =>
  * @return {Boolean}
  */
 const shouldIncludeFailureMessages = () =>
-	process.env.JEST_HTML_REPORTER_INCLUDE_FAILURE_MSG || config.includeFailureMsg || false;
+	parseBool(process.env.JEST_HTML_REPORTER_INCLUDE_FAILURE_MSG || config.includeFailureMsg || false);
 
 /**
  * Returns whether the report should contain console.logs or not
  * @return {Boolean}
  */
 const shouldIncludeConsoleLog = () =>
-	process.env.JEST_HTML_REPORTER_INCLUDE_CONSOLE_LOG || config.includeConsoleLog || false;
+	parseBool(process.env.JEST_HTML_REPORTER_INCLUDE_CONSOLE_LOG || config.includeConsoleLog || false);
 
 /**
  * Returns whether the report should use a dedicated .css file
  * @return {Boolean}
  */
 const shouldUseCssFile = () =>
-	process.env.JEST_HTML_REPORTER_USE_CSS_FILE || config.useCssFile || false;
+	parseBool(process.env.JEST_HTML_REPORTER_USE_CSS_FILE || config.useCssFile || false);
 
 /**
  * Returns the configured threshold (in seconds) when to apply a warning
@@ -113,11 +131,11 @@ const getSort = () =>
 	process.env.JEST_HTML_REPORTER_SORT || config.sort || 'default';
 
 /**
- * Returns the configured sorting method
- * @return {String}
+ * Returns the configured stable output option
+ * @return {Boolean}
  */
 const getStable = () =>
-	process.env.JEST_HTML_REPORTER_STABLE || config.stable || false;
+	parseBool(process.env.JEST_HTML_REPORTER_STABLE || config.stable || false);
 
 module.exports = {
 	config,

--- a/src/config.js
+++ b/src/config.js
@@ -112,6 +112,13 @@ const getDateFormat = () =>
 const getSort = () =>
 	process.env.JEST_HTML_REPORTER_SORT || config.sort || 'default';
 
+/**
+ * Returns the configured sorting method
+ * @return {String}
+ */
+const getStable = () =>
+	process.env.JEST_HTML_REPORTER_STABLE || config.stable || false;
+
 module.exports = {
 	config,
 	setup,
@@ -128,4 +135,5 @@ module.exports = {
 	getTheme,
 	getDateFormat,
 	getSort,
+	getStable,
 };

--- a/src/reportGenerator.js
+++ b/src/reportGenerator.js
@@ -99,11 +99,10 @@ class ReportGenerator {
 			// METADATA
 			const metaDataContainer = htmlOutput.ele('div', { id: 'metadata-container' });
 
-			const dateFormatValue = this.config.getDateFormat();
-			if (dateFormatValue) {
+			if (!this.config.getStable()) {
 				// Timestamp
 				const timestamp = new Date(data.startTime);
-				metaDataContainer.ele('div', { id: 'timestamp' }, `Start: ${dateFormat(timestamp, dateFormatValue)}`);
+				metaDataContainer.ele('div', { id: 'timestamp' }, `Start: ${dateFormat(timestamp, this.config.getDateFormat())}`);
 			}
 
 			// Test Summary

--- a/src/reportGenerator.js
+++ b/src/reportGenerator.js
@@ -98,9 +98,14 @@ class ReportGenerator {
 
 			// METADATA
 			const metaDataContainer = htmlOutput.ele('div', { id: 'metadata-container' });
-			// Timestamp
-			const timestamp = new Date(data.startTime);
-			metaDataContainer.ele('div', { id: 'timestamp' }, `Start: ${dateFormat(timestamp, this.config.getDateFormat())}`);
+
+			const dateFormatValue = this.config.getDateFormat();
+			if (dateFormatValue) {
+				// Timestamp
+				const timestamp = new Date(data.startTime);
+				metaDataContainer.ele('div', { id: 'timestamp' }, `Start: ${dateFormat(timestamp, dateFormatValue)}`);
+			}
+
 			// Test Summary
 			metaDataContainer.ele('div', { id: 'summary' }, `
 				${data.numTotalTests} tests --

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -118,28 +118,32 @@ describe('config', () => {
 	describe('shouldIncludeFailureMessages', () => {
 		it('should return the value from package.json or jesthtmlreporter.config.json', () => {
 			config.setConfigData({ includeFailureMsg: true });
-			expect(config.shouldIncludeFailureMessages()).toEqual(true);
+			expect(config.shouldIncludeFailureMessages()).toBeTruthy();
 		});
 		it('should return the environment variable', () => {
-			process.env.JEST_HTML_REPORTER_INCLUDE_FAILURE_MSG = true;
-			expect(config.shouldIncludeFailureMessages()).toEqual('true');
+			process.env.JEST_HTML_REPORTER_INCLUDE_FAILURE_MSG = 'true';
+			expect(config.shouldIncludeFailureMessages()).toBeTruthy();
+			process.env.JEST_HTML_REPORTER_INCLUDE_FAILURE_MSG = 'false';
+			expect(config.shouldIncludeFailureMessages()).toBeFalsy();
 		});
 		it('should return the default value if no setting was provided', () => {
-			expect(config.shouldIncludeFailureMessages()).toEqual(false);
+			expect(config.shouldIncludeFailureMessages()).toBeFalsy();
 		});
 	});
 
 	describe('shouldIncludeConsoleLog', () => {
 		it('should return the value from package.json or jesthtmlreporter.config.json', () => {
 			config.setConfigData({ includeConsoleLog: true });
-			expect(config.shouldIncludeConsoleLog()).toEqual(true);
+			expect(config.shouldIncludeConsoleLog()).toBeTruthy();
 		});
 		it('should return the environment variable', () => {
-			process.env.JEST_HTML_REPORTER_INCLUDE_CONSOLE_LOG = true;
-			expect(config.shouldIncludeConsoleLog()).toEqual('true');
+			process.env.JEST_HTML_REPORTER_INCLUDE_CONSOLE_LOG = 'true';
+			expect(config.shouldIncludeConsoleLog()).toBeTruthy();
+			process.env.JEST_HTML_REPORTER_INCLUDE_CONSOLE_LOG = 'false';
+			expect(config.shouldIncludeConsoleLog()).toBeFalsy();
 		});
 		it('should return the default value if no setting was provided', () => {
-			expect(config.shouldIncludeConsoleLog()).toEqual(false);
+			expect(config.shouldIncludeConsoleLog()).toBeFalsy();
 		});
 	});
 
@@ -187,12 +191,12 @@ describe('config', () => {
 
 	describe('getStable', () => {
 		it('should return the value from package.json or jesthtmlreporter.config.json', () => {
-			config.setConfigData({ stable: 'setInJson' });
-			expect(config.getStable()).toEqual('setInJson');
+			config.setConfigData({ stable: true });
+			expect(config.getStable()).toBeTruthy();
 		});
 		it('should return the environment variable', () => {
-			process.env.JEST_HTML_REPORTER_STABLE = 'setInEnv';
-			expect(config.getStable()).toEqual('setInEnv');
+			process.env.JEST_HTML_REPORTER_STABLE = true;
+			expect(config.getStable()).toBeTruthy();
 		});
 		it('should return the default value if no setting was provided', () => {
 			expect(config.getStable()).toBeFalsy();

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -18,6 +18,7 @@ describe('config', () => {
 			executionTimeWarningThreshold: null,
 			dateFormat: null,
 			sort: null,
+			stable: null,
 			executionMode: null,
 		});
 		delete process.env.JEST_HTML_REPORTER_OUTPUT_PATH;
@@ -30,6 +31,7 @@ describe('config', () => {
 		delete process.env.JEST_HTML_REPORTER_EXECUTION_TIME_WARNING_THRESHOLD;
 		delete process.env.JEST_HTML_REPORTER_DATE_FORMAT;
 		delete process.env.JEST_HTML_REPORTER_SORT;
+		delete process.env.JEST_HTML_REPORTER_STABLE;
 		delete process.env.JEST_HTML_REPORTER_EXECUTION_MODE;
 	});
 
@@ -180,6 +182,20 @@ describe('config', () => {
 		});
 		it('should return the default value if no setting was provided', () => {
 			expect(config.getSort()).toEqual('default');
+		});
+	});
+
+	describe('getStable', () => {
+		it('should return the value from package.json or jesthtmlreporter.config.json', () => {
+			config.setConfigData({ stable: 'setInJson' });
+			expect(config.getStable()).toEqual('setInJson');
+		});
+		it('should return the environment variable', () => {
+			process.env.JEST_HTML_REPORTER_STABLE = 'setInEnv';
+			expect(config.getStable()).toEqual('setInEnv');
+		});
+		it('should return the default value if no setting was provided', () => {
+			expect(config.getStable()).toBeFalsy();
 		});
 	});
 });

--- a/test/reportGenerator.spec.js
+++ b/test/reportGenerator.spec.js
@@ -19,8 +19,66 @@ describe('reportGenerator', () => {
 			const reportGenerator = new ReportGenerator(mockedConfig);
 
 			return reportGenerator.renderHtmlReport({ data: mockdata.jestResponse.multipleTestResults, stylesheet: '' })
-				.then(xmlBuilderOutput =>
-					expect(xmlBuilderOutput).not.toBeNull());
+				.then((xmlBuilderOutput) => {
+					expect(xmlBuilderOutput).not.toBeNull();
+					expect(xmlBuilderOutput.toString()).toMatch('<html>');
+					expect(xmlBuilderOutput.toString()).toMatch('<div id="timestamp">');
+				});
+		});
+
+		it('allows omission of the timestamp', () => {
+			const mockedConfig = {
+				getOutputFilepath: () => 'test-report.html',
+				getStylesheetFilepath: () => '../style/defaultTheme.css',
+				getPageTitle: () => 'Test Report',
+				getLogo: () => 'testLogo.png',
+				getDateFormat: () => undefined,
+				getSort: () => 'default',
+				shouldIncludeFailureMessages: () => true,
+				getExecutionTimeWarningThreshold: () => 5,
+				getCustomScriptFilepath: () => 'test.js',
+				shouldUseCssFile: () => false,
+			};
+			const reportGenerator = new ReportGenerator(mockedConfig);
+
+			return reportGenerator.renderHtmlReport({ data: mockdata.jestResponse.multipleTestResults, stylesheet: '' })
+				.then((xmlBuilderOutput) => {
+					expect(xmlBuilderOutput).not.toBeNull();
+					expect(xmlBuilderOutput.toString()).toMatch('<html>');
+					expect(xmlBuilderOutput.toString()).not.toMatch('<div id="timestamp">');
+				});
+		});
+
+		it('should generate identical output when called twice', () => {
+			const mockedConfig = {
+				getOutputFilepath: () => 'test-report.html',
+				getStylesheetFilepath: () => '../style/defaultTheme.css',
+				getPageTitle: () => 'Test Report',
+				getLogo: () => 'testLogo.png',
+				getDateFormat: () => undefined,
+				getSort: () => 'default',
+				shouldIncludeFailureMessages: () => true,
+				getExecutionTimeWarningThreshold: () => 5,
+				getCustomScriptFilepath: () => 'test.js',
+				shouldUseCssFile: () => false,
+			};
+			const mockedData = (n) => {
+				const result = Object.create(mockdata.jestResponse.multipleTestResults);
+				result.startTime += n;
+				return result;
+			};
+			const reportGenerators = [new ReportGenerator(mockedConfig), new ReportGenerator(mockedConfig)];
+			const promises = reportGenerators.map((generator, i) => generator.renderHtmlReport({
+				data: mockedData(32768 * i),
+				stylesheet: '',
+			}));
+			Promise.all(promises).then((xmlBuilderOutputs) => {
+				const xmlBuilderOutput = xmlBuilderOutputs.pop().toString();
+				expect(xmlBuilderOutput).toMatch('<html>');
+				xmlBuilderOutputs.forEach((otherOutput) => {
+					expect(otherOutput.toString()).toEqual(xmlBuilderOutput);
+				});
+			});
 		});
 
 		it('should return reject the promise if no data was provided', () => {

--- a/test/reportGenerator.spec.js
+++ b/test/reportGenerator.spec.js
@@ -3,19 +3,25 @@ const ReportGenerator = require('../src/reportGenerator');
 
 describe('reportGenerator', () => {
 	describe('renderHtmlReport', () => {
-		it('should return a HTML report based on the given input data', () => {
-			const mockedConfig = {
+		let mockedConfig;
+
+		beforeEach(() => {
+			mockedConfig = {
 				getOutputFilepath: () => 'test-report.html',
 				getStylesheetFilepath: () => '../style/defaultTheme.css',
 				getPageTitle: () => 'Test Report',
 				getLogo: () => 'testLogo.png',
 				getDateFormat: () => 'yyyy-mm-dd HH:MM:ss',
 				getSort: () => 'default',
+				getStable: () => false,
 				shouldIncludeFailureMessages: () => true,
 				getExecutionTimeWarningThreshold: () => 5,
 				getCustomScriptFilepath: () => 'test.js',
 				shouldUseCssFile: () => false,
 			};
+		});
+
+		it('should return a HTML report based on the given input data', () => {
 			const reportGenerator = new ReportGenerator(mockedConfig);
 
 			return reportGenerator.renderHtmlReport({ data: mockdata.jestResponse.multipleTestResults, stylesheet: '' })
@@ -26,42 +32,8 @@ describe('reportGenerator', () => {
 				});
 		});
 
-		it('allows omission of the timestamp', () => {
-			const mockedConfig = {
-				getOutputFilepath: () => 'test-report.html',
-				getStylesheetFilepath: () => '../style/defaultTheme.css',
-				getPageTitle: () => 'Test Report',
-				getLogo: () => 'testLogo.png',
-				getDateFormat: () => undefined,
-				getSort: () => 'default',
-				shouldIncludeFailureMessages: () => true,
-				getExecutionTimeWarningThreshold: () => 5,
-				getCustomScriptFilepath: () => 'test.js',
-				shouldUseCssFile: () => false,
-			};
-			const reportGenerator = new ReportGenerator(mockedConfig);
-
-			return reportGenerator.renderHtmlReport({ data: mockdata.jestResponse.multipleTestResults, stylesheet: '' })
-				.then((xmlBuilderOutput) => {
-					expect(xmlBuilderOutput).not.toBeNull();
-					expect(xmlBuilderOutput.toString()).toMatch('<html>');
-					expect(xmlBuilderOutput.toString()).not.toMatch('<div id="timestamp">');
-				});
-		});
-
 		it('should generate identical output when called twice', () => {
-			const mockedConfig = {
-				getOutputFilepath: () => 'test-report.html',
-				getStylesheetFilepath: () => '../style/defaultTheme.css',
-				getPageTitle: () => 'Test Report',
-				getLogo: () => 'testLogo.png',
-				getDateFormat: () => undefined,
-				getSort: () => 'default',
-				shouldIncludeFailureMessages: () => true,
-				getExecutionTimeWarningThreshold: () => 5,
-				getCustomScriptFilepath: () => 'test.js',
-				shouldUseCssFile: () => false,
-			};
+			mockedConfig.getStable = () => true;
 			const mockedData = (n) => {
 				const result = Object.create(mockdata.jestResponse.multipleTestResults);
 				result.startTime += n;
@@ -83,16 +55,6 @@ describe('reportGenerator', () => {
 
 		it('should return reject the promise if no data was provided', () => {
 			expect.assertions(1);
-			const mockedConfig = {
-				getOutputFilepath: () => 'test-report.html',
-				getStylesheetFilepath: () => '../style/defaultTheme.css',
-				getPageTitle: () => 'Test Report',
-				getDateFormat: () => 'yyyy-mm-dd HH:MM:ss',
-				getSort: () => 'default',
-				shouldIncludeFailureMessages: () => true,
-				getExecutionTimeWarningThreshold: () => 5,
-				getCustomScriptFilepath: () => 'test.js',
-			};
 			const reportGenerator = new ReportGenerator(mockedConfig);
 
 			return expect(reportGenerator.renderHtmlReport({ data: null, stylesheet: null })).rejects


### PR DESCRIPTION
## Issue

Running `jest --coverage` with this reporter multiple times produces different HTML files. This creates noise in a diff when documentation is checked in.

## Solution

Add an option ("stable") that omits the timestamp from the generated HTML.

## Notes

Open to suggestions for a better name for the option — "omit timestamp" seemed too limiting and obscured the purpose of the switch.

## Tests
```
✔ ~/Projects/jest-html-reporter [pyrogenic_stable_output_option|✔] 
18:01 $ jest --verbose
 PASS  test/config.spec.js
  config
    getStable
      ✓ should return the value from package.json or jesthtmlreporter.config.json (1ms)
      ✓ should return the environment variable
      ✓ should return the default value if no setting was provided
...
 PASS  test/reportGenerator.spec.js
  reportGenerator
    renderHtmlReport
      ✓ should return a HTML report based on the given input data (4ms)
      ✓ should generate identical output when called twice (2ms)
      ✓ should return reject the promise if no data was provided (1ms)
...
Test Suites: 5 passed, 5 total
Tests:       49 passed, 49 total
Snapshots:   0 total
Time:        1.086s
Ran all test suites.
```