### PR TITLE
Updated incorrectly documented settings parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Please note that all configuration properties are optional.
 | `includeFailureMsg` | `BOOLEAN` | If this setting is set to true, this will output the detailed failure message for each failed test. | `false`
 | `includeConsoleLog` | `BOOLEAN` | If set to true, this will output all triggered console logs for each test suite. | `false`
 | `styleOverridePath` | `STRING` | The path to a file containing CSS styles that should override the default styling.* | `null`
-| `shouldUseCssFile` | `BOOLEAN` | If set to true, the CSS styles will link in the current theme's .css file instead of inlining its content on the page | `false`
+| `useCssFile` | `BOOLEAN` | If set to true, the CSS styles will link in the current theme's .css file instead of inlining its content on the page | `false`
 | `customScriptPath` | `STRING` | Path to a javascript file that should be injected into the test report | `null`
 | `theme` | `STRING` | The name of the reporter themes to use when rendering the report. You can find the available themes in the [documentation](https://github.com/Hargne/jest-html-reporter/wiki/Test-Report-Themes) | `"defaultTheme"`
 | `logo` | `STRING` | Path to a logo that will be included in the header of the report | `null`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-html-reporter",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Jest test results processor for generating a summary in HTML",
   "main": "dist/main",
   "unpkg": "dist/main.min.js",


### PR DESCRIPTION
The setting `useCssFile` was incorrectly documented, and is now updated.
This fixes #62 