### PR TITLE
Update not to load CSS content if useCssFile and styleOverridePath supplied

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-html-reporter",
-  "version": "2.4.4",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -77,6 +77,13 @@ const getLogo = () =>
 	process.env.JEST_HTML_REPORTER_LOGO || config.logo || null;
 
 /**
+ * Returns whether there is a user defined stylesheet override path
+ */
+const getHasStyleOverridePath = () =>
+	Boolean(process.env.JEST_HTML_REPORTER_STYLE_OVERRIDE_PATH) ||
+	Boolean(config.styleOverridePath);
+
+/**
  * Returns whether the report should contain failure messages or not
  * @return {Boolean}
  */
@@ -96,6 +103,11 @@ const shouldIncludeConsoleLog = () =>
  */
 const shouldUseCssFile = () =>
 	process.env.JEST_HTML_REPORTER_USE_CSS_FILE || config.useCssFile || false;
+
+/**
+ * Returns whether the report should load the stylesheet content
+ */
+const shouldGetStylesheetContent = () => !(getHasStyleOverridePath() && shouldUseCssFile());
 
 /**
  * Returns the configured threshold (in seconds) when to apply a warning
@@ -132,12 +144,14 @@ module.exports = {
 	setConfigData,
 	getOutputFilepath,
 	getStylesheetFilepath,
+	getHasStyleOverridePath,
 	getCustomScriptFilepath,
 	getPageTitle,
 	getLogo,
 	shouldIncludeFailureMessages,
 	shouldIncludeConsoleLog,
 	shouldUseCssFile,
+	shouldGetStylesheetContent,
 	getExecutionTimeWarningThreshold,
 	getBoilerplatePath,
 	getTheme,

--- a/src/reportGenerator.js
+++ b/src/reportGenerator.js
@@ -18,13 +18,21 @@ class ReportGenerator {
 	generate({ data, ignoreConsole }) {
 		const fileDestination = this.config.getOutputFilepath();
 		const useCssFile = this.config.shouldUseCssFile();
+		const shouldGetStylesheetContent = this.config.shouldGetStylesheetContent();
 		let stylesheetPath = null;
+		let stylesheetContent = null;
 
 		if (useCssFile) {
 			stylesheetPath = this.config.getStylesheetFilepath();
 		}
 
-		return this.getStylesheetContent()
+		if (shouldGetStylesheetContent) {
+			stylesheetContent = () => this.getStylesheetContent();
+		} else {
+			stylesheetContent = () => Promise.resolve();
+		}
+
+		return stylesheetContent()
 			.then(stylesheet => this.renderHtmlReport({
 				data,
 				stylesheet,

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -89,6 +89,44 @@ describe('config', () => {
 		});
 	});
 
+	describe('getHasStyleOverridePath', () => {
+		it('should return true if the value from package.json or jesthtmlreporter.config.json is set', () => {
+			config.setConfigData({ styleOverridePath: 'setInJson.css' });
+			expect(config.getHasStyleOverridePath()).toEqual(true);
+		});
+		it('should return true if the environment variable is set', () => {
+			process.env.JEST_HTML_REPORTER_STYLE_OVERRIDE_PATH = 'setInEnv.css';
+			expect(config.getHasStyleOverridePath()).toEqual(true);
+		});
+		it('should return false if no setting was provided', () => {
+			expect(config.getHasStyleOverridePath()).toEqual(false);
+		});
+	});
+
+	describe('shouldGetStylesheetContent', () => {
+		it('should return false if styleOverridePath and useCssFile from package.json or jesthtmlreporter.config.json is set', () => {
+			config.setConfigData({
+				styleOverridePath: 'setInJson.css',
+				useCssFile: true,
+			});
+			expect(config.shouldGetStylesheetContent()).toEqual(false);
+		});
+		it('should return false if styleOverridePath and useCssFile environment variables are set', () => {
+			process.env.JEST_HTML_REPORTER_STYLE_OVERRIDE_PATH = 'setInEnv.css';
+			process.env.JEST_HTML_REPORTER_USE_CSS_FILE = true;
+			expect(config.shouldGetStylesheetContent()).toEqual(false);
+		});
+		it('should return true if only one variable is set', () => {
+			config.setConfigData({
+				useCssFile: true,
+			});
+			expect(config.shouldGetStylesheetContent()).toEqual(true);
+		});
+		it('should return true if no setting was provided', () => {
+			expect(config.shouldGetStylesheetContent()).toEqual(true);
+		});
+	});
+
 	describe('getPageTitle', () => {
 		it('should return the value from package.json or jesthtmlreporter.config.json', () => {
 			config.setConfigData({ pageTitle: 'setInJson' });


### PR DESCRIPTION
This PR fixes #70 by checking whether useCssFile and styleOverridePath have been supplied.

If both are supplied the report generator does not attempt to read the file contents of the CSS file before generating the report. This allows us to use any CSS file or URL for theming the report.

Without this PR if we keep a CSS file in a different directory to the report output directory, (e.g. project/src/theme.css) the generated link tag href for the css file location will be incorrect as it will be relative to the report directory, e.g. reports/src/theme.css

The issue before this PR was that the styleOverridePath was being used to load the content of the CSS file during report generation, we couldn't use a custom location (relative to report output dir) as the report generator was expecting to load the file, even if it doesn't need to.

This problem also prevents using static cdn stylesheets, e.g. `styleOverridePath='https://cdn.content/theme.css'` and also causes issues for CI systems that prevent CSS being loaded inline in the report document and don't allow directory traversal from the report directory.