### PR TITLE
Added invocations count in report, configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Please note that all configuration properties are optional.
 | `styleOverridePath` | `STRING` | The path to a file containing CSS styles that should override the default styling.* | `null`
 | `useCssFile` | `BOOLEAN` | If set to true, the CSS styles will link in the current theme's .css file instead of inlining its content on the page | `false`
 | `customScriptPath` | `STRING` | Path to a javascript file that should be injected into the test report | `null`
+| `displayTestInvocations` | `BOOLEAN` | Display test invocations (useful when used with jest-circus and retryTimes to display the amount of retries per test) | `false`
 | `theme` | `STRING` | The name of the reporter themes to use when rendering the report. You can find the available themes in the [documentation](https://github.com/Hargne/jest-html-reporter/wiki/Test-Report-Themes) | `"defaultTheme"`
 | `logo` | `STRING` | Path to a logo that will be included in the header of the report | `null`
 | `executionTimeWarningThreshold` | `NUMBER` | The threshold for test execution time (in seconds) in each test suite that will render a warning on the report page. 5 seconds is the default timeout in Jest. | `5`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-html-reporter",
-  "version": "2.4.4",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -314,6 +314,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2325,7 +2326,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2346,12 +2348,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2366,17 +2370,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2493,7 +2500,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2505,6 +2513,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2519,6 +2528,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2526,12 +2536,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2550,6 +2562,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2630,7 +2643,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2642,6 +2656,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2727,7 +2742,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2763,6 +2779,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2782,6 +2799,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2825,12 +2843,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5962,7 +5982,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-html-reporter",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-html-reporter",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Jest test results processor for generating a summary in HTML",
   "main": "dist/main",
   "unpkg": "dist/main.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-html-reporter",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Jest test results processor for generating a summary in HTML",
   "main": "dist/main",
   "unpkg": "dist/main.min.js",

--- a/src/config.js
+++ b/src/config.js
@@ -126,6 +126,14 @@ const getSort = () =>
 const getStatusIgnoreFilter = () =>
 	process.env.JEST_HTML_REPORTER_STATUS_FILTER || config.statusIgnoreFilter || null;
 
+/**
+ * Returns whether the report should contain test invocations number or not
+ * (apply for runs with retryTimes / jest-circus for example)
+ * @return {Boolean}
+ */
+const displayInvocations = () =>
+	process.env.DISPLAY_TEST_INVOCATIONS || config.dispayTestInvocations || false;
+
 module.exports = {
 	config,
 	setup,
@@ -144,4 +152,5 @@ module.exports = {
 	getDateFormat,
 	getSort,
 	getStatusIgnoreFilter,
+	displayInvocations,
 };

--- a/src/config.js
+++ b/src/config.js
@@ -132,7 +132,7 @@ const getStatusIgnoreFilter = () =>
  * @return {Boolean}
  */
 const displayInvocations = () =>
-	process.env.DISPLAY_TEST_INVOCATIONS || config.dispayTestInvocations || false;
+	process.env.DISPLAY_TEST_INVOCATIONS || config.displayTestInvocations || false;
 
 module.exports = {
 	config,

--- a/src/reportGenerator.js
+++ b/src/reportGenerator.js
@@ -201,6 +201,9 @@ class ReportGenerator {
 				}
 				// Append data to <tr>
 				testTr.ele('td', { class: 'result' }, (test.status === 'passed') ? `${test.status} in ${test.duration / 1000}s` : test.status);
+				if (this.config.displayInvocations()) {
+					testTr.ele('td', { class: 'suite' }, `Invocations ${test.invocations}`);
+				}
 			});
 
 			// Test Suite console.logs

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -21,6 +21,7 @@ describe('config', () => {
 			sort: null,
 			executionMode: null,
 			statusIgnoreFilter: null,
+			dispayTestInvocations: null,
 		});
 		delete process.env.JEST_HTML_REPORTER_OUTPUT_PATH;
 		delete process.env.JEST_HTML_REPORTER_THEME;
@@ -35,6 +36,7 @@ describe('config', () => {
 		delete process.env.JEST_HTML_REPORTER_SORT;
 		delete process.env.JEST_HTML_REPORTER_EXECUTION_MODE;
 		delete process.env.JEST_HTML_REPORTER_STATUS_FILTER;
+		delete process.env.DISPLAY_TEST_INVOCATIONS;
 	});
 
 	describe('setup', () => {
@@ -212,6 +214,20 @@ describe('config', () => {
 		});
 		it('should return the default value if no setting was provided', () => {
 			expect(config.getStatusIgnoreFilter()).toBeNull();
+		});
+	});
+
+	describe('displayInvocations', () => {
+		it('should return the value from package.json or jesthtmlreporter.config.json', () => {
+			config.setConfigData({ dispayTestInvocations: true });
+			expect(config.displayInvocations()).toEqual(true);
+		});
+		it('should return the environment variable', () => {
+			process.env.DISPLAY_TEST_INVOCATIONS = true;
+			expect(config.displayInvocations()).toEqual('true');
+		});
+		it('should return the default value if no setting was provided', () => {
+			expect(config.displayInvocations()).toEqual(false);
 		});
 	});
 });

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -21,7 +21,7 @@ describe('config', () => {
 			sort: null,
 			executionMode: null,
 			statusIgnoreFilter: null,
-			dispayTestInvocations: null,
+			displayTestInvocations: null,
 		});
 		delete process.env.JEST_HTML_REPORTER_OUTPUT_PATH;
 		delete process.env.JEST_HTML_REPORTER_THEME;
@@ -219,7 +219,7 @@ describe('config', () => {
 
 	describe('displayInvocations', () => {
 		it('should return the value from package.json or jesthtmlreporter.config.json', () => {
-			config.setConfigData({ dispayTestInvocations: true });
+			config.setConfigData({ displayTestInvocations: true });
 			expect(config.displayInvocations()).toEqual(true);
 		});
 		it('should return the environment variable', () => {

--- a/test/mockdata/jestResponse.mock.js
+++ b/test/mockdata/jestResponse.mock.js
@@ -108,6 +108,7 @@ module.exports = {
 						ancestorTitles: ['ancestor b'],
 						failureMessages: [],
 						numPassingAsserts: 0,
+						invocations: 2,
 					},
 					{
 						title: 'title c',
@@ -148,6 +149,7 @@ module.exports = {
 						ancestorTitles: ['ancestor c'],
 						failureMessages: ['failure'],
 						numPassingAsserts: 0,
+						invocations: 1,
 					},
 					{
 						title: 'title b',

--- a/test/reportGenerator.spec.js
+++ b/test/reportGenerator.spec.js
@@ -14,6 +14,7 @@ const mockedConfig = {
 	getCustomScriptFilepath: () => 'test.js',
 	shouldUseCssFile: () => false,
 	getStatusIgnoreFilter: () => null,
+	displayInvocations: () => false,
 };
 
 describe('reportGenerator', () => {
@@ -41,6 +42,23 @@ describe('reportGenerator', () => {
 
 			const result = reportGenerator.getReportBody({ data: mockdata.jestResponse.multipleTestResults, pageTitle: '' });
 			return expect(result.toString().indexOf('<tr class="passed">') !== -1).toEqual(false);
+		});
+
+		it('shouldn\'t output invocations when not required', () => {
+			const reportGenerator = new ReportGenerator(mockedConfig);
+
+			const result = reportGenerator.getReportBody({ data: mockdata.jestResponse.multipleTestResults, pageTitle: '' });
+			return expect(result.toString().indexOf('Invocations') !== -1).toEqual(false);
+		});
+
+		it('should output invocations when required', () => {
+			mockedConfig.displayInvocations = () => true;
+			const reportGenerator = new ReportGenerator(mockedConfig);
+
+			const result = reportGenerator.getReportBody({ data: mockdata.jestResponse.multipleTestResults, pageTitle: '' });
+			expect(result.toString().indexOf('Invocations 2') !== -1).toEqual(true);
+			expect(result.toString().indexOf('Invocations 1') !== -1).toEqual(true);
+			expect(result.toString().indexOf('Invocations undefined') !== -1).toEqual(true);
 		});
 	});
 });


### PR DESCRIPTION
We have a user case for this as by using jest-circus and retryTimes, we would like to see which test is retried and how many times, to detect flakiness and false positives (test passing because retried and matching in this way not wanted assertions).