### PR TITLE
Missing rootDir & append method

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -32,7 +32,7 @@
       "./dist",
       {
         "pageTitle": "Test Suite Reporter",
-        "outputPath": "testResultsProcessorResult.html",
+        "outputPath": "<rootDir>/testResultsProcessorResult.html",
         "includeFailureMsg": true,
         "includeConsoleLog": true,
         "useCssFile": true,


### PR DESCRIPTION
- Added back replacing Jest's own `<rootDir>` to the actual root directory
- Added and rewrote `append` method to append the report HTML inside the body tag of the provided file.