### PR TITLE
Replace <rootDir> in boilerplate config value

### DIFF
--- a/src/htmlreporter.ts
+++ b/src/htmlreporter.ts
@@ -59,10 +59,12 @@ class HTMLReporter {
 
     // Boilerplate Option
     if (!!this.getConfigValue("boilerplate")) {
-      const boilerplateContent = await fs.readFileSync(
-        this.getConfigValue("boilerplate") as string,
-        "utf8"
+      const boilerplatePath = this.replaceRootDirInPath(
+        this.jestConfig ? this.jestConfig.rootDir : "",
+        this.getConfigValue("boilerplate") as string
       );
+
+      const boilerplateContent = await fs.readFileSync(boilerplatePath, "utf8");
       return boilerplateContent.replace(
         "{jesthtmlreporter-content}",
         reportContent && reportContent.toString()


### PR DESCRIPTION
Currently `<rootDir>` is not being replaced for `boilerplate` config parameter.

This PR adds support of `<rootDir>` replacement in `boilerplate` config parameter.