### PR TITLE
Fix Append Without Report Already Present

### DIFF
--- a/src/htmlreporter.ts
+++ b/src/htmlreporter.ts
@@ -672,9 +672,10 @@ class HTMLReporter {
   public async appendToFile(filePath: string, content: any) {
     let parsedContent = content;
     // Check if the file exists or not
-    const fileToAppend = await fs.readFileSync(filePath, "utf8");
+    const fileExists = fs.existsSync(filePath)
     // The file exists - we need to strip all unnecessary html
-    if (fileToAppend) {
+    if (fileExists) {
+      const fileToAppend = await fs.readFileSync(filePath, "utf8");
       const contentSearch = /<body>(.*?)<\/body>/gm.exec(content);
       if (contentSearch) {
         const [strippedContent] = contentSearch;


### PR DESCRIPTION
### Description

If the index.html was not already present appending was failing to create it. This pull request should fix that behavior.

### Issues

When I attempt to run with my local version of the reporter I am getting the same issue seen in: #142

### How others should test
#### Append Enabled - No Existing Report
1. Delete your report specified in your output path e.g. `report.html` file if present.
2. Run your tests.
3. Observe report should be correctly created.

#### Append Enabled - Existing Report
1. Have an existing report in the location specified in your output path.
2. Run your tests.
3. Observe report should have new results appended to the existing report.

#### Append Disabled - No Existing Report
1. Delete your report specified in your output path e.g. `report.html` file if present.
2. Run your tests.
3. Observe report should be correctly created.

#### Append Disabled - Existing Report
1. Have an existing report in the location specified in your output path.
2. Run your tests.
3. Observe the existing report should be overwritten with the new run.

### Video - Example appended report
https://user-images.githubusercontent.com/26950305/165377692-96905c52-5eca-4406-89be-6676cb1add6c.mov