### PR TITLE
Adding npm install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,15 @@
 
 ## Installation
 
-```shell
+If using yarn:
+```
 $ yarn add jest-html-reporter --dev
 ```
 
+If using npm:
+```
+$ npm install jest-html-reporter --save-dev
+```
 ## Usage
 
 Configure Jest to process the test results by adding the following entry to the Jest config (jest.config.json):


### PR DESCRIPTION
This update adds npm install instructions as an alternative if not using yarn. 