### PR TITLE
change peerDependencies for typescript to include v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "xmlbuilder": "15.0.0"
   },
   "peerDependencies": {
-    "jest": "19.x - 30.x",
-    "typescript": "^3.7.x || ^4.3.x || ^5.x || ^6.x"
+    "jest": "19.x - 30.x"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "jest": "19.x - 30.x",
-    "typescript": "^3.7.x || ^4.3.x || ^5.x"
+    "typescript": "^3.7.x || ^4.3.x || ^5.x || ^6.x"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",


### PR DESCRIPTION
[Typescript 6 has been officially released March 23](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/) currently at `6.0.2` and I'm unable to properly upgrade because `jest-html-reporter`'s peerDependencies

This PR bumps those peer dependencies to allow typescript 6

I'm able to successfully run this locally adding the following to my `package.json`
```
"overrides": {
    "typescript": "6.0.2"
  }
}
```
I confess I may not be testing things properly enough but I thought I'd take a stab at submitting  a PR

You may be interested to note that [ts-jest has currently open issue regarding typescript6 support](https://github.com/kulshekhar/ts-jest/issues/5232) that likely runs deeper (various module resolution issues appear if you probe too deeply and attempt to remove `deprecations: 6.0` but similarly work okay if you use the `overrides` directive